### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/aleksey-suprun/meter-tracker.png?label=ready&title=Ready)](https://waffle.io/aleksey-suprun/meter-tracker)
 [![Build Status](https://travis-ci.org/aleksey-suprun/meter-tracker.svg?branch=master)](https://travis-ci.org/aleksey-suprun/meter-tracker)
 
 # Meter Tracker


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/aleksey-suprun/meter-tracker

This was requested by a real person (user aleksey-suprun) on waffle.io, we're not trying to spam you.
